### PR TITLE
fix(confconf): export missing types

### DIFF
--- a/packages/confconf/src/index.ts
+++ b/packages/confconf/src/index.ts
@@ -2,3 +2,7 @@ export * from "./confconf";
 export * from "./staticConfig";
 export * from "./envConfig";
 export * from "./devOnlyConfig";
+
+import type { ConfigProvider } from "./configProvider";
+import type { ValidationError } from "./ValidationError";
+export type { ConfigProvider, ValidationError };


### PR DESCRIPTION
Export ConfigProvider and ValidationError types so they can be used when needed.