### PR TITLE
feat(confconf)!: improve typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9318,7 +9318,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.41.0"
+        "@aws-sdk/client-secrets-manager": "^3.41.0",
+        "@sinclair/typebox": "^0.23.2",
+        "purify-ts": "^1.1.0"
       }
     },
     "packages/json": {
@@ -11080,7 +11082,9 @@
     "@confconf/integration-test": {
       "version": "file:packages/integration-test",
       "requires": {
-        "@aws-sdk/client-secrets-manager": "^3.41.0"
+        "@aws-sdk/client-secrets-manager": "^3.41.0",
+        "@sinclair/typebox": "^0.23.2",
+        "purify-ts": "^1.1.0"
       }
     },
     "@cspotcode/source-map-consumer": {

--- a/packages/confconf/jest.config.js
+++ b/packages/confconf/jest.config.js
@@ -5,6 +5,6 @@ module.exports = {
   ...baseConfig,
 
   globals: {
-    "ts-jest": { tsconfig: "tsconfig.test.json" },
+    "ts-jest": { tsconfig: "./test/tsconfig.json" },
   },
 };

--- a/packages/confconf/src/confconf.ts
+++ b/packages/confconf/src/confconf.ts
@@ -5,7 +5,7 @@ import { mergeDeep } from "./utils/deepMerge";
 import { ValidationError } from "./ValidationError";
 
 import type { ConfigProvider } from "./configProvider";
-import type { Schema, ValidateFunction } from "ajv";
+import type { Schema, ValidateFunction, JSONSchemaType } from "ajv";
 
 const ajv = new Ajv({
   strict: true,
@@ -19,11 +19,11 @@ const ajv = new Ajv({
   "modifier",
 ]);
 
-export interface ConfconfOpts {
+export interface ConfconfOpts<TSchema extends Schema> {
   /**
    * Schema against which the loaded configuration is validated
    */
-  schema: Schema;
+  schema: TSchema;
 
   /**
    * List of providers from which the configuration is loaded from
@@ -39,12 +39,12 @@ export interface ConfconfOpts {
   freezeConfig?: boolean;
 }
 
-class Confconf<TConfig> {
+class Confconf<TConfig = any, TSchema = any> {
   private readonly freeze: boolean;
   private readonly providers: ConfigProvider[];
   private readonly validator: ValidateFunction<TConfig>;
 
-  constructor(opts: ConfconfOpts) {
+  constructor(opts: ConfconfOpts<TSchema>) {
     this.freeze = opts.freezeConfig ?? true;
     this.providers = opts.providers;
 
@@ -78,7 +78,12 @@ class Confconf<TConfig> {
   }
 }
 
+export type ConfconfFn = {
+  <T = any>(opts: ConfconfOpts<JSONSchemaType<T>>): Confconf<T, JSONSchemaType<T>>;
+  <TConfig, TSchema extends Schema>(opts: ConfconfOpts<TSchema>): Confconf<TConfig, TSchema>;
+};
+
 /**
  * Creates a new instance of confconf
  */
-export const confconf = <TConfig>(opts: ConfconfOpts) => new Confconf<TConfig>(opts);
+export const confconf: ConfconfFn = (opts: any) => new Confconf(opts);

--- a/packages/confconf/test/.eslintrc.js
+++ b/packages/confconf/test/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     ".eslintrc.js",
   ],
   parserOptions: {
-    project: ["../tsconfig.test.json"],
+    project: ["./tsconfig.json"],
     tsconfigRootDir: __dirname,
   },
   extends: ["plugin:jest/recommended", "plugin:jest/style"],

--- a/packages/confconf/test/purify-ts.test.ts
+++ b/packages/confconf/test/purify-ts.test.ts
@@ -1,22 +1,15 @@
 import { Codec, number, string } from "purify-ts";
 
-import { confconf, staticConfig } from "../src";
-
-import type { GetType } from "purify-ts";
-
-const codec = Codec.interface({
-  a: string,
-  b: number,
-});
-
-const schema = codec.schema();
-
-type Config = GetType<typeof codec>;
+import { staticConfig } from "../src";
+import { purifyConfconf } from "./testUtils";
 
 describe("Usage with purify-ts", () => {
   it("works with purify-ts", async () => {
-    const configLoader = confconf<Config>({
-      schema,
+    const configLoader = purifyConfconf({
+      schema: Codec.interface({
+        a: string,
+        b: number,
+      }),
       providers: [
         staticConfig({
           a: "hello",
@@ -30,5 +23,9 @@ describe("Usage with purify-ts", () => {
       a: "hello",
       b: 10,
     });
+
+    // typescript checks
+    config.a;
+    config.b;
   });
 });

--- a/packages/confconf/test/testUtils.ts
+++ b/packages/confconf/test/testUtils.ts
@@ -1,0 +1,17 @@
+import { confconf } from "../src";
+
+import type { ConfconfOpts } from "../src";
+import type { Static, TSchema as TTypeboxSchema } from "@sinclair/typebox";
+import type { JSONSchema6 } from "json-schema";
+import type { Codec, GetType } from "purify-ts";
+
+export const typeboxConfconf = <TSchema extends TTypeboxSchema>(opts: ConfconfOpts<TSchema>) =>
+  confconf<Static<TSchema>, TSchema>(opts);
+
+export type PurifyConfconfOpts<T> = ConfconfOpts<Codec<T>>;
+
+export const purifyConfconf = <T>(opts: PurifyConfconfOpts<T>) =>
+  confconf<GetType<Codec<T>>, JSONSchema6>({
+    ...opts,
+    schema: opts.schema.schema(),
+  });

--- a/packages/confconf/test/tsconfig.json
+++ b/packages/confconf/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["../src/**/*", "./**/*"]
+}

--- a/packages/confconf/test/typebox.test.ts
+++ b/packages/confconf/test/typebox.test.ts
@@ -1,19 +1,16 @@
 import { Type } from "@sinclair/typebox";
 
-import { confconf, staticConfig } from "../src";
-
-import type { Static } from "@sinclair/typebox";
+import { staticConfig } from "../src";
+import { typeboxConfconf } from "./testUtils";
 
 const schema = Type.Object({
   a: Type.String(),
   b: Type.Number(),
 });
 
-type Config = Static<typeof schema>;
-
 describe("Usage with typebox", () => {
   it("works with typebox", async () => {
-    const configLoader = confconf<Config>({
+    const configLoader = typeboxConfconf({
       schema,
       providers: [
         staticConfig({
@@ -28,5 +25,9 @@ describe("Usage with typebox", () => {
       a: "hello",
       b: 10,
     });
+
+    // typescript checks
+    config.a;
+    config.b;
   });
 });

--- a/packages/confconf/tsconfig.json
+++ b/packages/confconf/tsconfig.json
@@ -8,5 +8,6 @@
 
     /* Emit */
     "outDir": "./dist" /* Specify an output folder for all emitted files. */
-  }
+  },
+  "include": ["tsconfig.json", "src/**/*"]
 }

--- a/packages/confconf/tsconfig.test.json
+++ b/packages/confconf/tsconfig.test.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src/**/*", "test/**/*"]
-}

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -11,6 +11,8 @@
   "author": "Tomi Turtiainen <tomi.turtiainen@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.41.0"
+    "@aws-sdk/client-secrets-manager": "^3.41.0",
+    "@sinclair/typebox": "^0.23.2",
+    "purify-ts": "^1.1.0"
   }
 }

--- a/packages/integration-test/test/aws-secret-manager-integration.test.ts
+++ b/packages/integration-test/test/aws-secret-manager-integration.test.ts
@@ -1,6 +1,9 @@
 import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
 import { awsSecretsManagerConfig } from "@confconf/aws-secrets-manager";
-import { confconf, staticConfig } from "@confconf/confconf";
+import { staticConfig } from "@confconf/confconf";
+import { Type } from "@sinclair/typebox";
+
+import { typeboxConfconf } from "./testUtils";
 
 describe("Integration tests", () => {
   it("loads aws secrets manager config", async () => {
@@ -15,18 +18,11 @@ describe("Integration tests", () => {
       send: mockSend,
     } as any;
 
-    const configLoader = confconf<{
-      a: string;
-      b: number;
-    }>({
-      schema: {
-        type: "object",
-        properties: {
-          a: { type: "string" },
-          b: { type: "number" },
-        },
-        required: ["a", "b"],
-      },
+    const configLoader = typeboxConfconf({
+      schema: Type.Object({
+        a: Type.String(),
+        b: Type.Number(),
+      }),
       providers: [
         awsSecretsManagerConfig({
           client: mockClient,
@@ -53,14 +49,10 @@ describe("Integration tests", () => {
       },
     });
 
-    const configLoader = confconf<any>({
-      schema: {
-        type: "object",
-        properties: {
-          a: { type: "string" },
-        },
-        required: ["a"],
-      },
+    const configLoader = typeboxConfconf({
+      schema: Type.Object({
+        a: Type.String(),
+      }),
       providers: [
         staticConfig({
           a: "hello",

--- a/packages/integration-test/test/confconf-integration.test.ts
+++ b/packages/integration-test/test/confconf-integration.test.ts
@@ -1,89 +1,174 @@
 import { confconf, envConfig, staticConfig, devOnlyConfig } from "@confconf/confconf";
+import { Type } from "@sinclair/typebox";
+import { Codec, number, string } from "purify-ts/Codec";
+
+import { typeboxConfconf } from "./testUtils";
+
+import type { ConfconfOpts } from "@confconf/confconf";
+import type { JSONSchema6 } from "json-schema";
+import type { GetType } from "purify-ts";
 
 describe("Integration tests", () => {
-  it("loads static config", async () => {
-    const configLoader = confconf<{
-      a: string;
-      b: number;
-    }>({
-      schema: {
-        type: "object",
-        properties: {
-          a: { type: "string" },
-          b: { type: "number" },
-        },
-      },
-      providers: [
-        staticConfig({
-          a: "hello",
-          b: 10,
-        }),
-      ],
-    });
+  describe("core providers", () => {
+    it("loads static config", async () => {
+      type Config = {
+        a: string;
+        b: number;
+      };
 
-    const config = await configLoader.loadAndValidate();
-    expect(config).toEqual({
-      a: "hello",
-      b: 10,
-    });
-  });
-
-  it("loads env config", async () => {
-    process.env = {
-      VAR_A: "hello",
-      VAR_B: "10",
-    };
-
-    const configLoader = confconf<{
-      a: string;
-      b: number;
-    }>({
-      schema: {
-        type: "object",
-        properties: {
-          a: { type: "string" },
-          b: { type: "number" },
-        },
-      },
-      providers: [
-        envConfig({
-          structure: {
-            a: "VAR_A",
-            b: "VAR_B",
+      const configLoader = confconf<Config>({
+        schema: {
+          type: "object",
+          properties: {
+            a: { type: "string" },
+            b: { type: "number" },
           },
-        }),
-      ],
+          required: ["a", "b"],
+        },
+        providers: [
+          staticConfig({
+            a: "hello",
+            b: 10,
+          }),
+        ],
+      });
+
+      const config = await configLoader.loadAndValidate();
+      expect(config).toEqual({
+        a: "hello",
+        b: 10,
+      });
+
+      // Typescript test
+      config.a;
+      config.b;
     });
 
-    const config = await configLoader.loadAndValidate();
-    expect(config).toEqual({
-      a: "hello",
-      b: 10,
+    it("loads env config", async () => {
+      process.env = {
+        VAR_A: "hello",
+        VAR_B: "10",
+      };
+
+      type Config = {
+        a: string;
+        b: number;
+      };
+
+      const configLoader = confconf<Config>({
+        schema: {
+          type: "object",
+          properties: {
+            a: { type: "string" },
+            b: { type: "number" },
+          },
+          required: ["a", "b"],
+        },
+        providers: [
+          envConfig({
+            structure: {
+              a: "VAR_A",
+              b: "VAR_B",
+            },
+          }),
+        ],
+      });
+
+      const config = await configLoader.loadAndValidate();
+      expect(config).toEqual({
+        a: "hello",
+        b: 10,
+      });
+    });
+
+    it("loads dev only config", async () => {
+      process.env.NODE_ENV = "development";
+
+      type Config = {
+        a: string;
+      };
+
+      const configLoader = confconf<Config>({
+        schema: {
+          type: "object",
+          properties: {
+            a: { type: "string" },
+          },
+          required: ["a"],
+        },
+        providers: [
+          devOnlyConfig({
+            a: "hello",
+          }),
+        ],
+      });
+
+      const config = await configLoader.loadAndValidate();
+      expect(config).toEqual({
+        a: "hello",
+      });
     });
   });
 
-  it("loads dev only config", async () => {
-    process.env.NODE_ENV = "development";
-
-    const configLoader = confconf<{
-      a: string;
-    }>({
-      schema: {
-        type: "object",
-        properties: {
-          a: { type: "string" },
-        },
-      },
-      providers: [
-        devOnlyConfig({
-          a: "hello",
+  describe("typebox integration", () => {
+    it("works with typebox", async () => {
+      const configLoader = typeboxConfconf({
+        schema: Type.Object({
+          a: Type.String(),
+          b: Type.Number(),
         }),
-      ],
-    });
+        providers: [
+          staticConfig({
+            a: "hello",
+            b: "10",
+          }),
+        ],
+      });
 
-    const config = await configLoader.loadAndValidate();
-    expect(config).toEqual({
-      a: "hello",
+      const config = await configLoader.loadAndValidate();
+      expect(config).toEqual({
+        a: "hello",
+        b: 10,
+      });
+
+      // typescript checks
+      config.a;
+      config.b;
+    });
+  });
+
+  describe("purify-ts integration", () => {
+    type PurifyConfconfOpts<T> = ConfconfOpts<Codec<T>>;
+
+    const purifyConfconf = <T>(opts: PurifyConfconfOpts<T>) =>
+      confconf<GetType<Codec<T>>, JSONSchema6>({
+        ...opts,
+        schema: opts.schema.schema(),
+      });
+
+    it("works with purify-ts", async () => {
+      const configLoader = purifyConfconf({
+        schema: Codec.interface({
+          a: string,
+          b: number,
+        }),
+        providers: [
+          staticConfig({
+            a: "hello",
+            b: "10",
+          }),
+        ],
+      });
+
+      const config = await configLoader.loadAndValidate();
+      expect(config).toEqual({
+        a: "hello",
+        b: 10,
+      });
+
+      // typescript checks
+      config.a;
+      config.b;
     });
   });
 });

--- a/packages/integration-test/test/testUtils.ts
+++ b/packages/integration-test/test/testUtils.ts
@@ -1,0 +1,7 @@
+import { confconf } from "@confconf/confconf";
+
+import type { ConfconfOpts } from "@confconf/confconf";
+import type { Static, TSchema as TTypeboxSchema } from "@sinclair/typebox";
+
+export const typeboxConfconf = <TSchema extends TTypeboxSchema>(opts: ConfconfOpts<TSchema>) =>
+  confconf<Static<TSchema>, TSchema>(opts);

--- a/packages/integration-test/tsconfig.json
+++ b/packages/integration-test/tsconfig.json
@@ -7,6 +7,9 @@
     "rootDir": "./test" /* Specify the root folder within your source files. */,
 
     /* Emit */
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+
+    "declaration": false,
+    "declarationMap": false
   }
 }


### PR DESCRIPTION
To better support type inference with libraries like typebox, add
separate generic type for the schema and the configuration itself.
This way libraries that provide a type function to get the underlying
type of a schema can be used with confconf.

BREAKING CHANGE: confconf constructor function now takes one or two type parameters